### PR TITLE
Patch files for github actions in main repo

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: Shellcheck
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  shellcheck:
+    name: Shellcheck push-helm-charts.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Start check
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: "."
+          pattern: "*.sh"
+          exclude: "./.git/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM golang:1.12-stretch
+FROM golang:1.14-stretch
 
 WORKDIR /tmp
 
  # Install Helm
-ENV HELM_VERSION=2.13.0
-RUN curl -sLO https://kubernetes-helm.storage.googleapis.com/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+ENV HELM_VERSION=2.16.9
+RUN curl -sLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/
 
  # Install a tiny azure client
-ENV AZCLI_VERSION=v0.3.1
+ENV AZCLI_VERSION=v0.3.2
 RUN curl -sLo /usr/local/bin/az https://github.com/carolynvs/az-cli/releases/download/$AZCLI_VERSION/az-linux-amd64 && \
     chmod +x /usr/local/bin/az
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'drone-helm'
+description: 'This is a plugin used by the Athens CI/CD system to publish Drone Charts'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
We're currently working on [#1638](https://github.com/gomods/athens/pull/1638) over in athens and need to be able to follow the exact flow of drone using github actions.

However, as this repository is doing some funky stuff and essentially just pushing stuff to blob storage we need to make it an action to get it working with both drone and github actions and be backwards compatible.

I've basically just made it an action, added shellcheck which fixes #2 and updated a bunch of stuff like the Go version, Helm and the location Helm is being pulled from.

I'd personally do this a bit differently to be honest but we're sticking to an exact replica of the drone configuration so we're not moving too many parts...