### PR TITLE
[#1704] Publishing charts blocked by deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp
 
  # Install Helm
 ENV HELM_VERSION=2.13.0
-RUN curl -sLO https://kubernetes-helm.storage.googleapis.com/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+RUN curl -sLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mv linux-amd64/helm /usr/local/bin/
 

--- a/push-helm-charts.sh
+++ b/push-helm-charts.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-helm init --client-only
+helm init --client-only --stable-repo-url https://charts.helm.sh/stable
 
 #####
 # set up the repo dir, and package up all charts


### PR DESCRIPTION
gomods/athens uses this repository to publish helm charts and it's currenty blocking the latest charts from being deployed which is frustating and captured here https://github.com/gomods/athens/issues/1704.

 Ideally we should replace it with latest helm, latest Go version etc however to unblock the build and get it working, this update should do that! Small updates to Dockerfile and push-helm-charts script to include changes to
stable URLs outlined in Helm release notes here https://helm.sh/blog/new-location-stable-incubator-charts/